### PR TITLE
[ci skip] chore: only rebase renovate PRs in case of a conflict (#1280)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":rebaseStalePrs"
+    "config:base"
   ],
   "labels": [
     "t: dependencies"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
### Motivation
At the moment we're getting a lot of force-pushes by renovate due to dependency PRs that are getting updated when the base branch changes. That is really not nessacary due to the new merge queue functionality and can be disabled.

### Modification
Configure renovate to only rebase conflicting PRs.

### Result
No more dependency updates force pushes when the base branch updates.

<!-- 
Thanks for taking your time and creating a pull request. Please note that we will not merge pull requests
which are not following our code style (https://google.github.io/styleguide/javaguide.html). Most of these
rules are checked while compile using checkstyle. On the other hand, please cover relevant code with tests.
These are showing the maintainers what to expect from your pull requests and ensures that changes to your
code will be consistent over time. See for example https://betterprogramming.pub/13-tips-for-writing-useful-unit-tests-ca20706b5368
if you need a bit of guidance while writing your tests.
-->

### Motivation
<!-- Explain the context and why you're making the change (what is the problem solved by this pr) -->

### Modification
<!-- Describe the modification you've done to the codebase -->

### Result
<!-- Describe the result of the pull request (what changed compared to before) -->

##### Other context
<!-- Other context of the pull request, a discussion, issue or anything else related -->
Fixes #
